### PR TITLE
Prevent get_field_data() from always returning null for string form IDs

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -2364,10 +2364,11 @@ class Caldera_Forms
 		global $processed_data;
 
 		if (is_string($form)) {
-			$form = Caldera_Forms_Forms::get_form($form);
-			if (!isset($form['ID']) || $form['ID'] !== $form) {
+			$form_obj = Caldera_Forms_Forms::get_form($form);
+			if (!isset($form_obj['ID']) || $form_obj['ID'] !== $form) {
 				return null;
 			}
+			$form = $form_obj;
 		}
 
 		if (!is_array($form)) {


### PR DESCRIPTION
The `$form` variable containing the original form ID is being overwritten too soon. The condition `$form['ID'] !== $form` will always return true because `$form['ID']` is being compared to the `$form` object.